### PR TITLE
Removed the check for default ctor when scanning for messages.

### DIFF
--- a/Obvs/Configuration/MessageTypes.cs
+++ b/Obvs/Configuration/MessageTypes.cs
@@ -25,21 +25,7 @@ namespace Obvs.Configuration
 
             EnsureTypesAreVisible(types);
 
-            EnsureDefaultConstructors(types);
-
             return types.ToArray();
-        }
-
-        private static void EnsureDefaultConstructors(Type[] types)
-        {
-            var noDefaultConstructor = types.Where(t => !t.HasDefaultConstructor()).ToArray();
-
-            if (noDefaultConstructor.Any())
-            {
-                throw new Exception(
-                    "The following message types do not have a default constructors and may not deserialize. Please add a default constuctor: " + Environment.NewLine +
-                    string.Join(Environment.NewLine, noDefaultConstructor.Select(t => string.Format("- {0}", t.FullName))));
-            }
         }
 
         private static void EnsureTypesAreVisible(IEnumerable<Type> types)


### PR DESCRIPTION
When scanning for message types at start-up, Obvs will die if the type does not have a public constructor. Ostensibly because this can inhibit deserialization.

But given the pluggable serialization architecture Obvs has, and the fact that many deserialization libraries can work with types that lack public ctors, IMHO it makes sense to make for Obvs core to be agnostic of this. 

Use case: trying to use F# records with Obvs.